### PR TITLE
[FEAT] 차단 정보 조회 API 구현 #374

### DIFF
--- a/src/main/java/FIS/iLUVit/controller/BlackUserController.java
+++ b/src/main/java/FIS/iLUVit/controller/BlackUserController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("black")
+@RequestMapping("black-user")
 public class BlackUserController {
 
     private final BlackUserService blackUserService;

--- a/src/main/java/FIS/iLUVit/controller/BlackUserController.java
+++ b/src/main/java/FIS/iLUVit/controller/BlackUserController.java
@@ -17,9 +17,9 @@ public class BlackUserController {
     /**
      * 차단 정보 조회
      */
-    @GetMapping("{blackUserId}")
-    public ResponseEntity<BlockedReasonResponse> getBlockedReason(@PathVariable("blackUserId") Long blackUserId) {
-        BlockedReasonResponse response = blackUserService.getBlockedReason(blackUserId);
+    @GetMapping("{loginId}")
+    public ResponseEntity<BlockedReasonResponse> getBlockedReason(@PathVariable("loginId") String loginId) {
+        BlockedReasonResponse response = blackUserService.getBlockedReason(loginId);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/FIS/iLUVit/controller/BlackUserController.java
+++ b/src/main/java/FIS/iLUVit/controller/BlackUserController.java
@@ -1,0 +1,25 @@
+package FIS.iLUVit.controller;
+
+import FIS.iLUVit.dto.blackUser.BlockedReasonResponse;
+import FIS.iLUVit.service.BlackUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("black")
+public class BlackUserController {
+
+    private final BlackUserService blackUserService;
+
+    /**
+     * 차단 정보 조회
+     */
+    @GetMapping("{blackUserId}")
+    public ResponseEntity<BlockedReasonResponse> getBlockedReason(@PathVariable("blackUserId") Long blackUserId) {
+        BlockedReasonResponse response = blackUserService.getBlockedReason(blackUserId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/FIS/iLUVit/domain/enumtype/UserStatus.java
+++ b/src/main/java/FIS/iLUVit/domain/enumtype/UserStatus.java
@@ -2,6 +2,7 @@ package FIS.iLUVit.domain.enumtype;
 
 public enum UserStatus {
     SUSPENDED,  // 영구정지
-    RESTRICTED, // 이용제한
-    WITHDRAWN   // 회원탈퇴
+    WITHDRAWN,   // 회원탈퇴
+    RESTRICTED_ADMIN, // 관리자에 의한 이용제한
+    RESTRICTED_REPORT // 신고 누적에 의한 이용제한
 }

--- a/src/main/java/FIS/iLUVit/dto/blackUser/BlockedReasonResponse.java
+++ b/src/main/java/FIS/iLUVit/dto/blackUser/BlockedReasonResponse.java
@@ -1,0 +1,18 @@
+package FIS.iLUVit.dto.blackUser;
+
+import FIS.iLUVit.domain.enumtype.UserStatus;
+import FIS.iLUVit.dto.report.ReportReasonResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class BlockedReasonResponse {
+    private UserStatus status;
+    private LocalDateTime blockedDate;      // 이용제한 혹은 영구정지를 당한 일시
+    private List<ReportReasonResponse> report;
+
+}

--- a/src/main/java/FIS/iLUVit/dto/blackUser/BlockedReasonResponse.java
+++ b/src/main/java/FIS/iLUVit/dto/blackUser/BlockedReasonResponse.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class BlockedReasonResponse {
-    private UserStatus status;
+    private UserStatus status;              // 차단된 유저의 상태
     private LocalDateTime blockedDate;      // 이용제한 혹은 영구정지를 당한 일시
     private List<ReportReasonResponse> report;
 

--- a/src/main/java/FIS/iLUVit/dto/blackUser/BlockedReasonResponse.java
+++ b/src/main/java/FIS/iLUVit/dto/blackUser/BlockedReasonResponse.java
@@ -11,8 +11,8 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class BlockedReasonResponse {
-    private UserStatus status;              // 차단된 유저의 상태
-    private LocalDateTime blockedDate;      // 이용제한 혹은 영구정지를 당한 일시
+    private UserStatus status;      // 차단된 유저의 상태
+    private String blockedDate;     // 이용제한 혹은 영구정지를 당한 일시
     private List<ReportReasonResponse> report;
 
 }

--- a/src/main/java/FIS/iLUVit/dto/report/ReportReasonResponse.java
+++ b/src/main/java/FIS/iLUVit/dto/report/ReportReasonResponse.java
@@ -13,6 +13,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class ReportReasonResponse {
     private ReportType reportType;          // 신고된 항목의 유형
-    private LocalDateTime reportDate;       // 신고 접수 일시
+    private String reportDate;       // 신고 접수 일시
     private ReportReason reportReason;      // 해당 게시글 혹은 댓글의 신고 사유
 }

--- a/src/main/java/FIS/iLUVit/dto/report/ReportReasonResponse.java
+++ b/src/main/java/FIS/iLUVit/dto/report/ReportReasonResponse.java
@@ -1,0 +1,19 @@
+package FIS.iLUVit.dto.report;
+
+import FIS.iLUVit.domain.enumtype.ReportReason;
+import FIS.iLUVit.domain.enumtype.ReportType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ReportReasonResponse {
+    private ReportType reportType;      // 신고된 항목의 유형
+    private LocalDateTime writtenDate;      // 신고된 게시글 혹은 댓글의 작성 일시
+    private ReportReason reportReason;  // 해당 게시글 혹은 댓글의 신고 사유
+}

--- a/src/main/java/FIS/iLUVit/dto/report/ReportReasonResponse.java
+++ b/src/main/java/FIS/iLUVit/dto/report/ReportReasonResponse.java
@@ -7,13 +7,12 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 @Builder
 @AllArgsConstructor
 public class ReportReasonResponse {
-    private ReportType reportType;      // 신고된 항목의 유형
-    private LocalDateTime writtenDate;      // 신고된 게시글 혹은 댓글의 작성 일시
-    private ReportReason reportReason;  // 해당 게시글 혹은 댓글의 신고 사유
+    private ReportType reportType;          // 신고된 항목의 유형
+    private LocalDateTime reportDate;       // 신고 접수 일시
+    private ReportReason reportReason;      // 해당 게시글 혹은 댓글의 신고 사유
 }

--- a/src/main/java/FIS/iLUVit/exception/BlackUserException.java
+++ b/src/main/java/FIS/iLUVit/exception/BlackUserException.java
@@ -1,0 +1,18 @@
+package FIS.iLUVit.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BlackUserException extends RuntimeException {
+
+    private BlackUserResult errorResult;
+
+    public BlackUserException() { super(); }
+
+    public BlackUserException(String message) { super(message); }
+
+    public BlackUserException(BlackUserResult errorResult) {
+        super();
+        this.errorResult = errorResult;
+    }
+}

--- a/src/main/java/FIS/iLUVit/exception/BlackUserResult.java
+++ b/src/main/java/FIS/iLUVit/exception/BlackUserResult.java
@@ -1,0 +1,15 @@
+package FIS.iLUVit.exception;
+
+import FIS.iLUVit.exception.exceptionHandler.ErrorResult;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BlackUserResult implements ErrorResult {
+    BLACK_USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "해당 로그인아이디를 가진 블랙유저가 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/FIS/iLUVit/repository/BlackUserRepository.java
+++ b/src/main/java/FIS/iLUVit/repository/BlackUserRepository.java
@@ -1,0 +1,8 @@
+package FIS.iLUVit.repository;
+
+import FIS.iLUVit.domain.BlackUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlackUserRepository extends JpaRepository<BlackUser, Long> {
+
+}

--- a/src/main/java/FIS/iLUVit/repository/BlackUserRepository.java
+++ b/src/main/java/FIS/iLUVit/repository/BlackUserRepository.java
@@ -3,6 +3,12 @@ package FIS.iLUVit.repository;
 import FIS.iLUVit.domain.BlackUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BlackUserRepository extends JpaRepository<BlackUser, Long> {
 
+    /**
+     * 해당 로그인아이디로 블랙유저를 조회합니다
+     */
+    Optional<BlackUser> findByLoginId(String loginId);
 }

--- a/src/main/java/FIS/iLUVit/repository/ReportDetailRepository.java
+++ b/src/main/java/FIS/iLUVit/repository/ReportDetailRepository.java
@@ -42,4 +42,9 @@ public interface ReportDetailRepository extends JpaRepository<ReportDetail, Long
     @Modifying(clearAutomatically = true)
     @Query("update ReportDetailComment  rdc set rdc.comment = null where rdc.comment.id in :commentIds")
     void setCommentIsNull(@Param("commentIds") List<Long> commentIds);
+
+    /**
+     * 해당 Report Id로 ReportDetail을 조회합니다
+     */
+    ReportDetail findByReportId(Long reportId);
 }

--- a/src/main/java/FIS/iLUVit/repository/ReportRepository.java
+++ b/src/main/java/FIS/iLUVit/repository/ReportRepository.java
@@ -1,6 +1,5 @@
 package FIS.iLUVit.repository;
 
-import FIS.iLUVit.domain.User;
 import FIS.iLUVit.domain.enumtype.ReportStatus;
 import FIS.iLUVit.domain.reports.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -39,5 +38,5 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     /**
      * 해당 사용자와 신고상태로 신고 리스트를 조회합니다
      */
-    List<Report> findByTargetUserAndStatus(User user, ReportStatus status);
+    List<Report> findByTargetUserIdAndStatus(Long userId, ReportStatus status);
 }

--- a/src/main/java/FIS/iLUVit/repository/ReportRepository.java
+++ b/src/main/java/FIS/iLUVit/repository/ReportRepository.java
@@ -1,5 +1,7 @@
 package FIS.iLUVit.repository;
 
+import FIS.iLUVit.domain.User;
+import FIS.iLUVit.domain.enumtype.ReportStatus;
 import FIS.iLUVit.domain.reports.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -33,4 +35,9 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
             "set r.targetId = null, r.status = 'DELETE' "+
             "where r.targetId in :commentIds")
     void setTargetIsNullAndStatusIsDelete(@Param("commentIds") List<Long> commentIds);
+
+    /**
+     * 해당 사용자와 신고상태로 신고 리스트를 조회합니다
+     */
+    List<Report> findByTargetUserAndStatus(User user, ReportStatus status);
 }

--- a/src/main/java/FIS/iLUVit/service/BlackUserService.java
+++ b/src/main/java/FIS/iLUVit/service/BlackUserService.java
@@ -47,12 +47,9 @@ public class BlackUserService {
         List<ReportReasonResponse> reasonResponses = new ArrayList<>();
 
         for(Report report : reports) {
-            ReportType reportType = report.getType();
-            LocalDateTime reportDate = report.getCreatedDate();
             ReportDetail reportDetail = reportDetailRepository.findByReportId(report.getId());
             ReportReason reportReason = reportDetail.getReason();
-
-            ReportReasonResponse reasonResponse = new ReportReasonResponse(reportType, reportDate, reportReason);
+            ReportReasonResponse reasonResponse = new ReportReasonResponse(report.getType(), report.getCreatedDate(), reportReason);
             reasonResponses.add(reasonResponse);
         }
         BlockedReasonResponse response = new BlockedReasonResponse(blackUser.getUserStatus(), blackUser.getCreatedDate(), reasonResponses);

--- a/src/main/java/FIS/iLUVit/service/BlackUserService.java
+++ b/src/main/java/FIS/iLUVit/service/BlackUserService.java
@@ -38,7 +38,7 @@ public class BlackUserService {
     public BlockedReasonResponse getBlockedReason(String loginId) {
 
         BlackUser blackUser = blackUserRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new UserException(UserErrorResult.USER_NOT_EXIST));
+                .orElseThrow(() -> new BlackUserException(BlackUserResult.BLACK_USER_NOT_EXIST));
         Long userId = blackUser.getUserId();
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorResult.USER_NOT_EXIST));

--- a/src/main/java/FIS/iLUVit/service/BlackUserService.java
+++ b/src/main/java/FIS/iLUVit/service/BlackUserService.java
@@ -48,11 +48,11 @@ public class BlackUserService {
 
         for(Report report : reports) {
             ReportType reportType = report.getType();
-            LocalDateTime writtenDate = report.getCreatedDate();
+            LocalDateTime reportDate = report.getCreatedDate();
             ReportDetail reportDetail = reportDetailRepository.findByReportId(report.getId());
             ReportReason reportReason = reportDetail.getReason();
 
-            ReportReasonResponse reasonResponse = new ReportReasonResponse(reportType, writtenDate, reportReason);
+            ReportReasonResponse reasonResponse = new ReportReasonResponse(reportType, reportDate, reportReason);
             reasonResponses.add(reasonResponse);
         }
         BlockedReasonResponse response = new BlockedReasonResponse(blackUser.getUserStatus(), blackUser.getCreatedDate(), reasonResponses);

--- a/src/main/java/FIS/iLUVit/service/BlackUserService.java
+++ b/src/main/java/FIS/iLUVit/service/BlackUserService.java
@@ -1,0 +1,62 @@
+package FIS.iLUVit.service;
+
+import FIS.iLUVit.domain.BlackUser;
+import FIS.iLUVit.domain.User;
+import FIS.iLUVit.domain.enumtype.ReportReason;
+import FIS.iLUVit.domain.enumtype.ReportStatus;
+import FIS.iLUVit.domain.enumtype.ReportType;
+import FIS.iLUVit.domain.reports.Report;
+import FIS.iLUVit.domain.reports.ReportDetail;
+import FIS.iLUVit.dto.blackUser.BlockedReasonResponse;
+import FIS.iLUVit.dto.report.ReportReasonResponse;
+import FIS.iLUVit.exception.*;
+import FIS.iLUVit.repository.BlackUserRepository;
+import FIS.iLUVit.repository.ReportDetailRepository;
+import FIS.iLUVit.repository.ReportRepository;
+import FIS.iLUVit.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BlackUserService {
+
+    private final BlackUserRepository blackUserRepository;
+    private final UserRepository userRepository;
+    private final ReportRepository reportRepository;
+    private final ReportDetailRepository reportDetailRepository;
+
+    /**
+     * 차단 정보를 조회합니다
+     */
+    public BlockedReasonResponse getBlockedReason(Long blackUserId) {
+
+        BlackUser blackUser = blackUserRepository.findById(blackUserId)
+                .orElseThrow(() -> new UserException(UserErrorResult.USER_NOT_EXIST));
+        Long userId = blackUser.getUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorResult.USER_NOT_EXIST));
+
+        List<Report> reports = reportRepository.findByTargetUserAndStatus(user, ReportStatus.DELETE);
+        List<ReportReasonResponse> reasonResponses = new ArrayList<>();
+
+        for(Report report : reports) {
+            ReportType reportType = report.getType();
+            LocalDateTime writtenDate = report.getCreatedDate();
+            ReportDetail reportDetail = reportDetailRepository.findByReportId(report.getId());
+            ReportReason reportReason = reportDetail.getReason();
+
+            ReportReasonResponse reasonResponse = new ReportReasonResponse(reportType, writtenDate, reportReason);
+            reasonResponses.add(reasonResponse);
+        }
+        BlockedReasonResponse response = new BlockedReasonResponse(blackUser.getUserStatus(), blackUser.getCreatedDate(), reasonResponses);
+
+        return response;
+    }
+}

--- a/src/main/java/FIS/iLUVit/service/BlackUserService.java
+++ b/src/main/java/FIS/iLUVit/service/BlackUserService.java
@@ -35,9 +35,9 @@ public class BlackUserService {
     /**
      * 차단 정보를 조회합니다
      */
-    public BlockedReasonResponse getBlockedReason(Long blackUserId) {
+    public BlockedReasonResponse getBlockedReason(String loginId) {
 
-        BlackUser blackUser = blackUserRepository.findById(blackUserId)
+        BlackUser blackUser = blackUserRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new UserException(UserErrorResult.USER_NOT_EXIST));
         Long userId = blackUser.getUserId();
         User user = userRepository.findById(userId)


### PR DESCRIPTION
## 🌱 관련 이슈
- close # #374 

## 📌 작업 내용
- 블랙유저인 경우 차단 사유 등의 정보를 조회하는 API를 구현합니다

## 📚 기타
- UserController와 UserService에 해당 메서드를 위치시키면 다른 메소드에는 불필요한 의존관계가 너무 많이 생기는 것 같아서 BlackUserController와 BlackUserService로 분리하여 생성해주었습니다! 리스너를 이용한 스케줄링 메소드도 BlackUserService에 있으면 좋을 것 같아서 분리하였는데 어떻게 생각하시는지 의견 남겨주시면 감사하겠습니다 !!
