### PR TITLE
[FEAT] 신고누적 시 블랙유저 등록 로직 구현

### DIFF
--- a/src/main/java/FIS/iLUVit/domain/BlackUser.java
+++ b/src/main/java/FIS/iLUVit/domain/BlackUser.java
@@ -11,9 +11,6 @@ import javax.persistence.*;
 
 @Entity
 @Getter
-@Inheritance(strategy = InheritanceType.JOINED)
-@DiscriminatorColumn
-@DiscriminatorValue("null")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "black_user")
 public class BlackUser extends BaseImageEntity {
@@ -22,6 +19,7 @@ public class BlackUser extends BaseImageEntity {
     @GeneratedValue
     private Long id;
 
+    @Column(unique = true)
     private Long userId;              // 사용자 기본키
     private String nickName;          // 닉네임
     private String loginId;           // 로그인 아이디
@@ -36,7 +34,7 @@ public class BlackUser extends BaseImageEntity {
     private Location location;
     @Enumerated(EnumType.STRING)
     private Auth auth;                  // Teacher, Director or Parent
-    @Column(name = "dtype", insertable = false, updatable = false)
+    @Column(name = "dtype")
     private String dtype;               // Teacher or Parent
 
     @Enumerated(EnumType.STRING)
@@ -56,6 +54,9 @@ public class BlackUser extends BaseImageEntity {
         this.location = user.getLocation();
         this.auth = user.getAuth();
         this.dtype = user.getDtype();
+        this.profileImagePath = user.getProfileImagePath();
+        this.infoImagePath = user.getInfoImagePath();
+        this.imgCnt = user.getImgCnt();
         this.userStatus = userStatus;
     }
 }

--- a/src/main/java/FIS/iLUVit/domain/BlackUser.java
+++ b/src/main/java/FIS/iLUVit/domain/BlackUser.java
@@ -42,4 +42,20 @@ public class BlackUser extends BaseImageEntity {
     @Enumerated(EnumType.STRING)
     private UserStatus userStatus;      // Suspended, Restricted or Withdrawn
 
+    public BlackUser(User user, UserStatus userStatus) {
+        this.userId = user.getId();
+        this.nickName = user.getNickName();
+        this.loginId = user.getLoginId();
+        this.password = user.getPassword();
+        this.phoneNumber = user.getPhoneNumber();
+        this.emailAddress = user.getEmailAddress();
+        this.name = user.getName();
+        this.address = user.getAddress();
+        this.detailAddress = user.getDetailAddress();
+        this.readAlarm = user.getReadAlarm();
+        this.location = user.getLocation();
+        this.auth = user.getAuth();
+        this.dtype = user.getDtype();
+        this.userStatus = userStatus;
+    }
 }

--- a/src/main/java/FIS/iLUVit/domain/enumtype/UserStatus.java
+++ b/src/main/java/FIS/iLUVit/domain/enumtype/UserStatus.java
@@ -1,8 +1,7 @@
 package FIS.iLUVit.domain.enumtype;
 
 public enum UserStatus {
-    SUSPENDED,  // 영구정지
-    WITHDRAWN,   // 회원탈퇴
-    RESTRICTED_ADMIN, // 관리자에 의한 이용제한
-    RESTRICTED_REPORT // 신고 누적에 의한 이용제한
+    BAN,                    // 영구정지
+    WITHDRAWN,              // 회원탈퇴
+    RESTRICTED_SEVEN_DAYS   // 일주일간 이용제한
 }

--- a/src/main/java/FIS/iLUVit/repository/ReportRepository.java
+++ b/src/main/java/FIS/iLUVit/repository/ReportRepository.java
@@ -39,4 +39,7 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
      * 해당 사용자와 신고상태로 신고 리스트를 조회합니다
      */
     List<Report> findByTargetUserIdAndStatus(Long userId, ReportStatus status);
+
+    @Query("SELECT r.targetUser, COUNT(r) FROM Report r WHERE r.status = :status GROUP BY r.targetUser, r.status")
+    List<Object[]> countReportsByUserAndStatus(@Param("status") ReportStatus status);
 }

--- a/src/main/java/FIS/iLUVit/service/BlackUserService.java
+++ b/src/main/java/FIS/iLUVit/service/BlackUserService.java
@@ -66,7 +66,7 @@ public class BlackUserService {
     /**
      * 신고 누적으로 인한 블랙유저를 등록합니다
      */
-    @Scheduled(cron = "0 */4 * * * *") // 4시간 마다 실행
+    @Scheduled(cron = "0 0 */4 * * *") // 4시간 마다 실행
     public void makeBlackUserUponReportThreshold() {
         // 사용자별 신고 횟수 정보 조회
         List<Object[]> userReportCounts = reportRepository.countReportsByUserAndStatus(ReportStatus.DELETE);

--- a/src/main/java/FIS/iLUVit/service/BlackUserService.java
+++ b/src/main/java/FIS/iLUVit/service/BlackUserService.java
@@ -13,6 +13,7 @@ import FIS.iLUVit.exception.*;
 import FIS.iLUVit.repository.BlackUserRepository;
 import FIS.iLUVit.repository.ReportDetailRepository;
 import FIS.iLUVit.repository.ReportRepository;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -28,7 +29,6 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class BlackUserService {
-
     private final BlackUserRepository blackUserRepository;
     private final ReportRepository reportRepository;
     private final ReportDetailRepository reportDetailRepository;
@@ -74,13 +74,16 @@ public class BlackUserService {
         // 각 사용자별로 신고 횟수 확인 후 누적횟수에 따른 블랙유저로 등록
         for (Object[] userReportRow : userReportCounts) {
             User user = (User) userReportRow[0];
-            int reportCount = (int) userReportRow[1];
-            if (reportCount >= THRESHOLD_FOR_RESTRICTION && reportCount <= THRESHOLD_FOR_SUSPENDED) {
-                // 신고 누적 횟수가 이용제한 한계에 도달한 경우, 사용자를 이용제한 상태로 변경
-                processBlacklistUser(user, UserStatus.RESTRICTED_REPORT);
-            } else if (reportCount >= THRESHOLD_FOR_SUSPENDED) {
-                // 신고 누적 횟수가 영구정지 한계에 도달한 경우, 사용자를 영구정지 상태로 변경
-                processBlacklistUser(user, UserStatus.SUSPENDED);
+            Long reportCount = (Long) userReportRow[1];
+            int reportCountInt = reportCount.intValue();
+            if(user.getPhoneNumber() != null) {
+                if (reportCountInt >= THRESHOLD_FOR_RESTRICTION && reportCountInt <= THRESHOLD_FOR_SUSPENDED) {
+                    // 신고 누적 횟수가 이용제한 한계에 도달한 경우, 사용자를 이용제한 상태로 변경
+                    processBlacklistUser(user, UserStatus.RESTRICTED_SEVEN_DAYS);
+                } else if (reportCountInt >= THRESHOLD_FOR_SUSPENDED) {
+                    // 신고 누적 횟수가 영구정지 한계에 도달한 경우, 사용자를 영구정지 상태로 변경
+                    processBlacklistUser(user, UserStatus.BAN);
+                }
             }
         }
     }
@@ -107,5 +110,5 @@ public class BlackUserService {
                 .ifPresent(blackUser -> {
                     throw new UserException(UserErrorResult.USER_IS_WITHDRAWN);
                 });
-
+    }
 }

--- a/src/main/java/FIS/iLUVit/service/BlackUserService.java
+++ b/src/main/java/FIS/iLUVit/service/BlackUserService.java
@@ -4,6 +4,7 @@ import FIS.iLUVit.domain.BlackUser;
 import FIS.iLUVit.domain.User;
 import FIS.iLUVit.domain.enumtype.ReportReason;
 import FIS.iLUVit.domain.enumtype.ReportStatus;
+import FIS.iLUVit.domain.enumtype.UserStatus;
 import FIS.iLUVit.domain.reports.Report;
 import FIS.iLUVit.domain.reports.ReportDetail;
 import FIS.iLUVit.dto.blackUser.BlockedReasonResponse;
@@ -12,8 +13,9 @@ import FIS.iLUVit.exception.*;
 import FIS.iLUVit.repository.BlackUserRepository;
 import FIS.iLUVit.repository.ReportDetailRepository;
 import FIS.iLUVit.repository.ReportRepository;
-import FIS.iLUVit.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,12 +26,15 @@ import java.util.List;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class BlackUserService {
 
     private final BlackUserRepository blackUserRepository;
-    private final UserRepository userRepository;
     private final ReportRepository reportRepository;
     private final ReportDetailRepository reportDetailRepository;
+
+    private static final int THRESHOLD_FOR_RESTRICTION = 3; // 이용제한 신고 누적 수 한계
+    private static final int THRESHOLD_FOR_SUSPENDED = 7;   // 영구정지 신고 누적 수 한계
 
     /**
      * 차단 정보를 조회합니다
@@ -56,5 +61,37 @@ public class BlackUserService {
         BlockedReasonResponse response = new BlockedReasonResponse(blackUser.getUserStatus(), formattedBlackUserDate, reasonResponses);
 
         return response;
+    }
+
+    /**
+     * 신고 누적으로 인한 블랙유저를 등록합니다
+     */
+    @Scheduled(cron = "0 */4 * * * *") // 4시간 마다 실행
+    public void makeBlackUserUponReportThreshold() {
+        // 사용자별 신고 횟수 정보 조회
+        List<Object[]> userReportCounts = reportRepository.countReportsByUserAndStatus(ReportStatus.DELETE);
+
+        // 각 사용자별로 신고 횟수 확인 후 누적횟수에 따른 블랙유저로 등록
+        for (Object[] userReportRow : userReportCounts) {
+            User user = (User) userReportRow[0];
+            int reportCount = (int) userReportRow[1];
+            if (reportCount >= THRESHOLD_FOR_RESTRICTION && reportCount <= THRESHOLD_FOR_SUSPENDED) {
+                // 신고 누적 횟수가 이용제한 한계에 도달한 경우, 사용자를 이용제한 상태로 변경
+                processBlacklistUser(user, UserStatus.RESTRICTED_REPORT);
+            } else if (reportCount >= THRESHOLD_FOR_SUSPENDED) {
+                // 신고 누적 횟수가 영구정지 한계에 도달한 경우, 사용자를 영구정지 상태로 변경
+                processBlacklistUser(user, UserStatus.SUSPENDED);
+            }
+        }
+    }
+
+    /**
+     * 해당 유저를 블랙유저로 추가하고 개인정보를 삭제합니다
+     */
+    private void processBlacklistUser(User user, UserStatus status) {
+        // 블랙리스트에 사용자를 추가
+        blackUserRepository.save(new BlackUser(user, status));
+        // 사용자의 개인 정보를 삭제
+        user.deletePersonalInfo();
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #378 

## 📌 작업 내용
- 신고 누적 수 한계에 도달하면 신고 누적 수 한계에 맞는 블랙유저 등급을 부여하여 블랙유저로 등록합니다

## 📚 기타
- 우선 4시간에 한 번씩 해당 메서드가 호출되는 것으로 cron 표현식을 설정해두었습니다. 지금은 @Scheduled 어노테이션을 사용하여 주기적으로 검사하지만 추후에 아이러빗 관리자 레포로 넘어가서 @EntityListeners를 이용한 방식으로 구현해볼 수도 있을 것 같습니다! 신고 3회 혹은 7회 한계점이 도달한 바로 그 순간 트랜잭션이 커밋된 것을 감지하여 @PostUpdate 쓰면 될 법도 해서요. 그렇게 되면 신고 누적 횟수 한계점에 도달한 순간 바로 블랙유저로 등록할 수 있으니 지금처럼 이미 한계점을 넘은 유저가 블랙유저가 되지 않는 시간(최대 4시간)이 존재하지 않습니다. 대신 해당 엔티티의 영속성 컨텍스트는 아이러빗 관리자 어플리케이션에서 관리하는 것이기 때문에 아이러빗 관리자에서 구현을 해야하는데, 블랙유저 도메인과 구조가 마련된 아이러빗 어플리케이션에서 더 빠르게 구현할 수 있을 것 같아 우선은 해당 pr처럼 로직을 구현했습니다.