### PR TITLE
[FEAT] 차단 정보 조회 API에 응답객체 속성 추가 #384

### DIFF
--- a/src/main/java/FIS/iLUVit/domain/enumtype/UserStatus.java
+++ b/src/main/java/FIS/iLUVit/domain/enumtype/UserStatus.java
@@ -1,8 +1,7 @@
 package FIS.iLUVit.domain.enumtype;
 
 public enum UserStatus {
-    SUSPENDED,  // 영구정지
-    WITHDRAWN,   // 회원탈퇴
-    RESTRICTED_ADMIN, // 관리자에 의한 이용제한
-    RESTRICTED_REPORT // 신고 누적에 의한 이용제한
+    BAN,                    // 영구정지
+    WITHDRAWN,              // 회원탈퇴
+    RESTRICTED_SEVEN_DAYS   // 일주일간 이용제한
 }

--- a/src/main/java/FIS/iLUVit/dto/blackUser/BlockedReasonResponse.java
+++ b/src/main/java/FIS/iLUVit/dto/blackUser/BlockedReasonResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class BlockedReasonResponse {
+    private String nickname;        // 차단된 유저의 닉네임
     private UserStatus status;      // 차단된 유저의 상태
     private String blockedDate;     // 이용제한 혹은 영구정지를 당한 일시
     private List<ReportReasonResponse> report;

--- a/src/main/java/FIS/iLUVit/service/BlackUserService.java
+++ b/src/main/java/FIS/iLUVit/service/BlackUserService.java
@@ -54,7 +54,7 @@ public class BlackUserService {
             reasonResponses.add(reasonResponse);
         }
         String formattedBlackUserDate = blackUser.getCreatedDate().format(formatter);
-        BlockedReasonResponse response = new BlockedReasonResponse(blackUser.getUserStatus(), formattedBlackUserDate, reasonResponses);
+        BlockedReasonResponse response = new BlockedReasonResponse(blackUser.getNickName(), blackUser.getUserStatus(), formattedBlackUserDate, reasonResponses);
 
         return response;
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #374 

## 📌 작업 내용
- 차단정보조회 API 응답값에 차단된 사용자의 닉네임을 추가합니다

## 📚 기타
- 
