### PR TITLE
[FEAT] 유저차단 기능 관련 게시글, 댓글 로직 추가 

### DIFF
--- a/src/main/java/FIS/iLUVit/controller/PostController.java
+++ b/src/main/java/FIS/iLUVit/controller/PostController.java
@@ -139,8 +139,8 @@ public class PostController {
      * 작성내용: HOT 게시판 게시글 전체 조회
      */
     @GetMapping("search/hot-board")
-    public Slice<PostPreviewDto> getPostByHotBoard(@RequestParam(value = "center_id", required = false) Long centerId, Pageable pageable) {
-        return postService.findPostByHeartCnt(centerId, pageable);
+    public Slice<PostPreviewDto> getPostByHotBoard(@Login Long userId, @RequestParam(value = "center_id", required = false) Long centerId, Pageable pageable) {
+        return postService.findPostByHeartCnt(userId, centerId, pageable);
     }
 
     /**

--- a/src/main/java/FIS/iLUVit/controller/PostController.java
+++ b/src/main/java/FIS/iLUVit/controller/PostController.java
@@ -109,11 +109,9 @@ public class PostController {
      * 작성내용: 게시글 제목+내용+보드 검색 (각 게시판 별 검색)
      */
     @GetMapping("search/in-board")
-    public Slice<PostPreviewDto> getPostByBoard(
-            @RequestParam("board_id") Long boardId,
-            @RequestParam("input") String keyword,
-            Pageable pageable) {
-        return postService.searchByBoard(boardId, keyword, pageable);
+    public Slice<PostPreviewDto> getPostByBoard(@Login Long userId, @RequestParam("board_id") Long boardId,
+                                                @RequestParam("input") String keyword, Pageable pageable) {
+        return postService.searchByBoard(userId, boardId, keyword, pageable);
     }
 
     /**

--- a/src/main/java/FIS/iLUVit/domain/Blocked.java
+++ b/src/main/java/FIS/iLUVit/domain/Blocked.java
@@ -15,11 +15,11 @@ public class Blocked extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "blocker_id")
-    private User blocker;              // 차단한 사람
+    @JoinColumn(name = "blocking_user_id")
+    private User blockingUser;              // 차단한 사람
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "blocked_id")
-    private User blocked;                // 차단 당한 사람
+    @JoinColumn(name = "blocked_user_id")
+    private User blockedUser;                // 차단 당한 사람
 
 }

--- a/src/main/java/FIS/iLUVit/dto/comment/CommentResponse.java
+++ b/src/main/java/FIS/iLUVit/dto/comment/CommentResponse.java
@@ -25,10 +25,41 @@ public class CommentResponse {
     private LocalTime time;
     private Boolean anonymous;
     private Boolean canDelete;
-
+    private Boolean isBlocked;  // 댓글 차단 여부
     private List<CommentResponse> answers;
 
-    public CommentResponse(Comment comment, Long userId) {
+    public CommentResponse(Comment comment, Long userId, List<CommentResponse> subComments, Boolean isBlocked) {
+        this.id = comment.getId();
+        User writer = comment.getUser();
+        if (writer != null) {
+            if (Objects.equals(writer.getId(), userId)) {
+                this.canDelete = true;
+            } else {
+                this.canDelete = false;
+            }
+
+            if (comment.getAnonymous()) {
+                if (comment.getAnonymousOrder().equals(-1)) {
+                    this.nickname = "익명(작성자)";
+                } else {
+                    this.nickname = "익명" + comment.getAnonymousOrder();
+                }
+            } else {
+                this.profileImage = writer.getProfileImagePath();
+                this.writer_id = writer.getId();
+                this.nickname = writer.getNickName();
+            }
+        }
+        this.heartCnt = comment.getHeartCnt();
+        this.anonymous = comment.getAnonymous();
+        this.content = comment.getContent();
+        this.date = comment.getDate();
+        this.time = comment.getTime();
+        this.isBlocked = isBlocked;
+        this.answers = subComments;
+    }
+
+    public CommentResponse(Comment comment, Long userId, Boolean isBlocked) {
         this.id = comment.getId();
         User writer = comment.getUser();
         if (writer != null) {
@@ -55,9 +86,8 @@ public class CommentResponse {
         this.content = comment.getContent();
         this.date = comment.getDate();
         this.time = comment.getTime();
-        this.answers = comment.getSubComments().stream()
-                .map(c -> new CommentResponse(c, userId))
-                .collect(Collectors.toList());
+        this.isBlocked = isBlocked;
+        this.answers = null;
     }
 }
 

--- a/src/main/java/FIS/iLUVit/dto/post/PostResponse.java
+++ b/src/main/java/FIS/iLUVit/dto/post/PostResponse.java
@@ -45,7 +45,7 @@ public class PostResponse {
 
     private Boolean canDelete;
 
-    public PostResponse(Post post, List<String> encodedImages, String encodedProfileImage, Long userId) {
+    public PostResponse(Post post, List<String> infoImages, String profileImage,Long userId, List<CommentResponse> commentResponses) {
         this.id = post.getId();
         if (post.getUser() != null) {
             if (Objects.equals(post.getUser().getId(), userId)) {
@@ -66,10 +66,10 @@ public class PostResponse {
         this.title = post.getTitle();
         this.content = post.getContent();
 
-        this.profileImage = encodedProfileImage;
-        this.images = encodedImages;
+        this.profileImage = profileImage;
+        this.images = infoImages;
 
-        this.imgCnt = encodedImages.size();
+        this.imgCnt = infoImages.size();
         this.heartCnt = post.getHeartCnt();
 
         if (post.getBoard() != null) {
@@ -81,9 +81,7 @@ public class PostResponse {
             }
         }
 
-        this.comments = post.getComments().stream()
-                .filter(c -> c.getParentComment() == null)
-                .map(c -> new CommentResponse(c, userId)).collect(Collectors.toList());
+        this.comments = commentResponses;
         this.commentCnt = post.getCommentCnt();
 
     }

--- a/src/main/java/FIS/iLUVit/repository/BlockedRepository.java
+++ b/src/main/java/FIS/iLUVit/repository/BlockedRepository.java
@@ -1,7 +1,11 @@
 package FIS.iLUVit.repository;
 
 import FIS.iLUVit.domain.Blocked;
+import FIS.iLUVit.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BlockedRepository extends JpaRepository<Blocked, Long> {
+    List<Blocked> findByBlockingUser(User blockingUser);
 }

--- a/src/main/java/FIS/iLUVit/repository/PostRepository.java
+++ b/src/main/java/FIS/iLUVit/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package FIS.iLUVit.repository;
 
 import FIS.iLUVit.domain.Post;
+import FIS.iLUVit.domain.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -52,16 +53,18 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
         게시글 하트 개수가 가장 많은 3개의 게시글 리스트를 불러옵니다.
      */
     @Query("select p from Post p join p.board b " +
-            "where b.center.id is null and p.heartCnt >= :heartCnt order by p.postCreateDate desc ")
-    List<Post> findTop3ByHeartCnt(@Param("heartCnt") int heartCnt, Pageable pageable);
+            "where b.center.id is null and p.heartCnt >= :heartCnt and p.user not in :blockedUsers " +
+            "order by p.postCreateDate desc ")
+    List<Post> findTop3ByHeartCnt(@Param("heartCnt") int heartCnt, List<User> blockedUsers, Pageable pageable);
 
     /*
         시설에 있는 게시글중 하트가 가장 많은 3개의 게시글 리스트를 불러옵니다.
      */
     @Query("select p from Post p join p.board b " +
-            "where b.center.id = :centerId and p.heartCnt >= :heartCnt order by p.postCreateDate desc ")
+            "where b.center.id = :centerId and p.heartCnt >= :heartCnt and p.user not in :blockedUsers " +
+            "order by p.postCreateDate desc ")
     List<Post> findTop3ByHeartCntWithCenter(@Param("heartCnt") int heartCnt, @Param("centerId") Long centerId,
-                                            Pageable pageable);
+                                            List<User> blockedUser, Pageable pageable);
 
 
     /*

--- a/src/main/java/FIS/iLUVit/repository/PostRepositoryCustom.java
+++ b/src/main/java/FIS/iLUVit/repository/PostRepositoryCustom.java
@@ -1,10 +1,12 @@
 package FIS.iLUVit.repository;
 
+import FIS.iLUVit.domain.User;
 import FIS.iLUVit.dto.post.PostPreviewDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import java.util.Collection;
+import java.util.List;
 
 public interface PostRepositoryCustom {
 
@@ -26,5 +28,5 @@ public interface PostRepositoryCustom {
     /*
         시설 id가 주어진 시설 id와 같고 게시글 엔티티의 하트 개수가 주어진 하트 개수보다 크거나 같은지 확인하여 게시글 미리보기 DTO를 불러옵니다.
      */
-    Slice<PostPreviewDto> findHotPosts(Long centerId, Integer heartCnt, Pageable pageable);
+    Slice<PostPreviewDto> findHotPosts(Long centerId, Integer heartCnt, List<User> blockedUsers, Pageable pageable);
 }

--- a/src/main/java/FIS/iLUVit/repository/PostRepositoryCustom.java
+++ b/src/main/java/FIS/iLUVit/repository/PostRepositoryCustom.java
@@ -13,17 +13,17 @@ public interface PostRepositoryCustom {
     /*
         시설 id가 주어진 시설 id 리스트에 속하거나 null인지를 확인하고 keywordContains 메서드를 호출하여 키워드 검색을 적용하여 게시글 미리보기 DTO 객체를 불러옵니다.
      */
-    Slice<PostPreviewDto> findInCenterByKeyword(Collection<Long> centerIds, String keyword, Pageable pageable);
+    Slice<PostPreviewDto> findInCenterByKeyword(Collection<Long> centerIds, String keyword, List<User> blockedUsers, Pageable pageable);
 
     /*
         시설 id가 주어진 시설 id와 동일한지 확인하고 keywordContains 메서드를 호출하여 키워드 검색을 적용하여 게시글 미리보기 DTO 객체를 불러옵니다.
      */
-    Slice<PostPreviewDto> findByCenterAndKeyword(Long centerId, String keyword, Pageable pageable);
+    Slice<PostPreviewDto> findByCenterAndKeyword(Long centerId, String keyword, List<User> blockedUsers, Pageable pageable);
 
     /*
         시설 id가 주어진 시설 id 값과 같은지 확인하고 keywordContains 메서드를 호출하여 키워드 검색을 적용하여 게시글 미리보기 DTO 객체를 불러옵니다.
      */
-    Slice<PostPreviewDto> findByBoardAndKeyword(Long boardId, String keyword, Pageable pageable);
+    Slice<PostPreviewDto> findByBoardAndKeyword(Long boardId, String keyword, List<User> blockedUsers, Pageable pageable);
 
     /*
         시설 id가 주어진 시설 id와 같고 게시글 엔티티의 하트 개수가 주어진 하트 개수보다 크거나 같은지 확인하여 게시글 미리보기 DTO를 불러옵니다.

--- a/src/main/java/FIS/iLUVit/repository/PostRepositoryImpl.java
+++ b/src/main/java/FIS/iLUVit/repository/PostRepositoryImpl.java
@@ -1,5 +1,7 @@
 package FIS.iLUVit.repository;
 
+import FIS.iLUVit.domain.Blocked;
+import FIS.iLUVit.domain.User;
 import FIS.iLUVit.dto.post.PostPreviewDto;
 import FIS.iLUVit.dto.post.QPostPreviewDto;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -94,12 +96,12 @@ public class PostRepositoryImpl extends PostQueryMethod implements PostRepositor
         시설 id가 주어진 시설 id와 같고 게시글 엔티티의 하트 개수가 주어진 하트 개수보다 크거나 같은지 확인하여 게시글 미리보기 DTO를 불러옵니다.
      */
     @Override
-    public Slice<PostPreviewDto> findHotPosts(Long centerId, Integer heartCnt, Pageable pageable) {
+    public Slice<PostPreviewDto> findHotPosts(Long centerId, Integer heartCnt, List<User> blockedUsers, Pageable pageable) {
         List<PostPreviewDto> posts = jpaQueryFactory.select(new QPostPreviewDto(post))
                 .from(post)
                 .join(post.board, board).fetchJoin()
                 .leftJoin(board.center, center).fetchJoin()
-                .where(centerIdEq(centerId), post.heartCnt.goe(heartCnt))
+                .where(centerIdEq(centerId), post.heartCnt.goe(heartCnt), post.user.notIn(blockedUsers))
                 .orderBy(post.postCreateDate.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)

--- a/src/main/java/FIS/iLUVit/repository/PostRepositoryImpl.java
+++ b/src/main/java/FIS/iLUVit/repository/PostRepositoryImpl.java
@@ -26,12 +26,12 @@ public class PostRepositoryImpl extends PostQueryMethod implements PostRepositor
         시설 id가 주어진 시설 id 리스트에 속하거나 null인지를 확인하고 keywordContains 메서드를 호출하여 키워드 검색을 적용하여 게시글 미리보기 DTO 객체를 불러옵니다.
      */
     @Override
-    public Slice<PostPreviewDto> findInCenterByKeyword(Collection<Long> centerIds, String keyword, Pageable pageable) {
+    public Slice<PostPreviewDto> findInCenterByKeyword(Collection<Long> centerIds, String keyword, List<User> blockedUsers, Pageable pageable) {
         List<PostPreviewDto> posts = jpaQueryFactory.select(new QPostPreviewDto(post))
                 .from(post)
                 .join(post.board, board).fetchJoin()
                 .leftJoin(board.center, center).fetchJoin()
-                .where(centerIdIn(centerIds).or(center.id.isNull()), keywordContains(keyword))
+                .where(centerIdIn(centerIds).or(center.id.isNull()), keywordContains(keyword), post.user.notIn(blockedUsers))
                 .orderBy(post.createdDate.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
@@ -49,12 +49,12 @@ public class PostRepositoryImpl extends PostQueryMethod implements PostRepositor
         시설 id가 주어진 시설 id와 동일한지 확인하고 keywordContains 메서드를 호출하여 키워드 검색을 적용하여 게시글 미리보기 DTO 객체를 불러옵니다.
      */
     @Override
-    public Slice<PostPreviewDto> findByCenterAndKeyword(Long centerId, String keyword, Pageable pageable) {
+    public Slice<PostPreviewDto> findByCenterAndKeyword(Long centerId, String keyword, List<User> blockedUsers, Pageable pageable) {
         List<PostPreviewDto> posts = jpaQueryFactory.select(new QPostPreviewDto(post))
                 .from(post)
                 .join(post.board, board).fetchJoin()
                 .leftJoin(board.center, center).fetchJoin()
-                .where(centerIdEq(centerId), keywordContains(keyword))
+                .where(centerIdEq(centerId), keywordContains(keyword), post.user.notIn(blockedUsers))
                 .orderBy(post.createdDate.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
@@ -73,11 +73,11 @@ public class PostRepositoryImpl extends PostQueryMethod implements PostRepositor
         시설 id가 주어진 시설 id 값과 같은지 확인하고 keywordContains 메서드를 호출하여 키워드 검색을 적용하여 게시글 미리보기 DTO 객체를 불러옵니다.
      */
     @Override
-    public Slice<PostPreviewDto> findByBoardAndKeyword(Long boardId, String keyword, Pageable pageable) {
+    public Slice<PostPreviewDto> findByBoardAndKeyword(Long boardId, String keyword, List<User> blockedUsers, Pageable pageable) {
         List<PostPreviewDto> posts = jpaQueryFactory.select(new QPostPreviewDto(post))
                 .from(post)
                 .join(post.board, board).fetchJoin()
-                .where(board.id.eq(boardId), keywordContains(keyword))
+                .where(board.id.eq(boardId), keywordContains(keyword), post.user.notIn(blockedUsers))
                 .orderBy(post.postUpdateDate.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)

--- a/src/main/java/FIS/iLUVit/service/CommentService.java
+++ b/src/main/java/FIS/iLUVit/service/CommentService.java
@@ -1,5 +1,6 @@
 package FIS.iLUVit.service;
 
+import FIS.iLUVit.domain.Blocked;
 import FIS.iLUVit.domain.alarms.Alarm;
 import FIS.iLUVit.dto.comment.CommentDto;
 import FIS.iLUVit.dto.comment.CommentRequest;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -29,57 +31,57 @@ public class CommentService {
     private final UserRepository userRepository;
     private final ReportRepository reportRepository;
     private final ReportDetailRepository reportDetailRepository;
-
+    private final BlockedRepository blockedRepository;
     private final AlarmRepository alarmRepository;
 
-    public Long saveNewComment(Long userId, Long postId, Long p_commentId, CommentRequest request) {
-        if (userId == null) {
-            throw new CommentException(CommentErrorResult.UNAUTHORIZED_USER_ACCESS);
-        }
+    public Long saveNewComment(Long userId, Long postId, Long parentCommentId, CommentRequest request) {
 
-        User findUser = userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorResult.USER_NOT_EXIST));
-        Post findPost = postRepository.findByIdWithBoard(postId)
+
+        Post post = postRepository.findByIdWithBoard(postId)
                 .orElseThrow(() -> new PostException(PostErrorResult.POST_NOT_EXIST));
 
-
-        // anonymous false 일 때 order = null
-        // anonymous true 일 때 order = n
+        // anonymous false 일 때 order = null , anonymous true 일 때 order = n
         Integer anonymousOrder = null;
 
-        /**
-            작성자: 이창윤
-            작성시간: 2022/08/02 11:13 AM
-            내용: 익명3이 댓글을 또 달면 3을 가져와야됨.
-                새로운 유저가 익명으로 댓글을 달면 익명4로 등록함.
-                작성자가 익명으로 작성하면 익명(작성자)로 표시됨.
-                닉네임 공개로 작성할 경우 order = null
+        /*
+            익명3이 댓글을 또 달면 3을 가져와야됨.새로운 유저가 익명으로 댓글을 달면 익명4로 등록함.
+            작성자가 익명으로 작성하면 익명(작성자)로 표시됨.닉네임 공개로 작성할 경우 order = null
         */
         // 익명 작성일 때
         if (request.getAnonymous()) {
             // 게시글 작성자 == 댓글 작성자이면 -1
-            if (Objects.equals(findPost.getUser().getId(), userId)) {
+            if (Objects.equals(post.getUser().getId(), userId)) {
                 anonymousOrder = -1;
             } else {
-                Comment findComment = commentRepository.findFirstByPostAndUserAndAnonymous(findPost, findUser, request.getAnonymous())
+                Comment findComment = commentRepository.findFirstByPostAndUserAndAnonymous(post, user, request.getAnonymous())
                     .orElse(null);
                 // 게시글 내 이미 익명으로 작성한 댓글이 있으면 댓글에서 익명 순서 가져옴
                 if (findComment != null) {
                     anonymousOrder = findComment.getAnonymousOrder();
                 } else { // 없으면 게시글 order +1 후 익명 순서 새로 가져옴
-                    findPost.plusAnonymousOrder();
-                    anonymousOrder = findPost.getAnonymousOrder();
+                    post.plusAnonymousOrder();
+                    anonymousOrder = post.getAnonymousOrder();
                 }
             }
         }
 
-        Comment comment = new Comment(request.getAnonymous(), request.getContent(), findPost, findUser, anonymousOrder);
-        if (p_commentId != null) {
-            Comment parentComment = commentRepository.getById(p_commentId);
+        Comment comment = new Comment(request.getAnonymous(), request.getContent(), post, user, anonymousOrder);
+
+        if (parentCommentId != null) {
+            Comment parentComment = commentRepository.getById(parentCommentId);
             comment.updateParentComment(parentComment);
         }
-        if (!userId.equals(findPost.getUser().getId())) { // 본인 게시글에 댓글단 건 알림 X
-            Alarm alarm = new PostAlarm(findPost.getUser(), findPost, comment);
+
+        // 게시글을 쓴 유저가 차단한 유저를 조회한다
+        List<User> blockedUsers = blockedRepository.findByBlockingUser(post.getUser()).stream()
+                .map(Blocked::getBlockedUser)
+                .collect(Collectors.toList());
+
+        // 본인 게시글에 댓글 단 것은 알림 X , 댓글을 쓴 사람이 게시글을 쓴 사람이 차단한 유저이면 알림 X
+        if (!user.equals(post.getUser()) && !blockedUsers.contains(user)) {
+            Alarm alarm = new PostAlarm(post.getUser(), post, comment);
             alarmRepository.save(alarm);
             String type = "아이러빗";
             AlarmUtils.publishAlarmEvent(alarm, type);

--- a/src/main/java/FIS/iLUVit/service/PostService.java
+++ b/src/main/java/FIS/iLUVit/service/PostService.java
@@ -201,6 +201,7 @@ public class PostService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorResult.USER_NOT_EXIST));
 
+        // 유저가 차단한 유저를 조회한다
         List<User> blockedUsers = getBlockedUsers(user);
 
         List<CommentResponse> commentResponses = new ArrayList<>();


### PR DESCRIPTION
## 🌱 관련 이슈
- close #392 

## 📌 작업 내용
- 게시글 조회 API 로직 추가 ( getBoardDetailsByPublic, getBoardDetailsByCenter, getPostByHotBoard )
-  게시글 검색 API 로직 추가 ( getPost, getPostByCenter, getPostByBoard )
-  게시글 상세 조회(댓글도 같이 조회됨) API 로직 추가( getPostDetails )
-  댓글 알림 발행 로직 추가 ( createComment )

## 📚 기타

