### PR TITLE
[FEAT] 유저차단 기능 관련 쪽지 로직 추가

### DIFF
--- a/src/main/java/FIS/iLUVit/repository/ChatRepository.java
+++ b/src/main/java/FIS/iLUVit/repository/ChatRepository.java
@@ -1,12 +1,15 @@
 package FIS.iLUVit.repository;
 
 import FIS.iLUVit.domain.Chat;
+import FIS.iLUVit.domain.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
@@ -17,7 +20,8 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
     @Query("select c from Chat c " +
             "join fetch c.chatRoom cr " +
             "where cr.id = :roomId " +
-            "and cr.receiver.id = :userId order by c.createdDate desc ")
-    Slice<Chat> findByChatRoom(@Param("userId") Long userId, @Param("roomId") Long roomId, Pageable pageable);
+            "and cr.receiver.id = :userId and cr.sender not in :blockedUsers " +
+            "order by c.createdDate desc ")
+    Slice<Chat> findByChatRoom(@Param("userId") Long userId, List<User> blockedUsers, @Param("roomId") Long roomId, Pageable pageable);
 
 }

--- a/src/main/java/FIS/iLUVit/service/ChatService.java
+++ b/src/main/java/FIS/iLUVit/service/ChatService.java
@@ -10,12 +10,15 @@ import FIS.iLUVit.domain.alarms.ChatAlarm;
 import FIS.iLUVit.exception.*;
 import FIS.iLUVit.repository.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cglib.core.Block;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +30,7 @@ public class ChatService {
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final BlockedRepository blockedRepository;
     private final ImageService imageService;
 
     private final AlarmRepository alarmRepository;
@@ -79,10 +83,18 @@ public class ChatService {
         myRoom.updatePartnerId(partnerRoom.getId());
         partnerRoom.updatePartnerId(myRoom.getId());
 
-        Alarm alarm = new ChatAlarm(receiveUser, sendUser, anonymousInfo);
-        alarmRepository.save(alarm);
-        String type = "아이러빗";
-        AlarmUtils.publishAlarmEvent(alarm, type);
+        // 쪽지를 받은 유저가 자신이 차단한 유저를 조회
+        List<User> blockedUsers = blockedRepository.findByBlockingUser(receiveUser).stream()
+                .map(Blocked::getBlockedUser)
+                .collect(Collectors.toList());
+
+        // 쪽지를 보낸 유저가 쪽지를 받는 유저에게 차단된 상태라면 알림을 발행하지 않음
+        if(!blockedUsers.contains(sendUser)) {
+            Alarm alarm = new ChatAlarm(receiveUser, sendUser, anonymousInfo);
+            alarmRepository.save(alarm);
+            String type = "아이러빗";
+            AlarmUtils.publishAlarmEvent(alarm, type);
+        }
 
         chatRepository.save(myChat);
         Chat savedChat = chatRepository.save(partnerChat);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #397 

## 📌 작업 내용
- 차단된 유저가 쪽지를 보낼 경우는 쪽지를 받았다는 알림을 발행하지 않도록 로직을 수정하였습니다
- 차단된 유저가 쪽지를 보낸 경우 채팅방 상세조회에서 차단된 이후 보낸 쪽지가 더 이상 보이지 않습니다

## 📚 기타
