### PR TITLE
[FEAT] 유저차단 기능 관련 쪽지 로직 추가

### DIFF
--- a/src/main/java/FIS/iLUVit/dto/chat/ChatDto.java
+++ b/src/main/java/FIS/iLUVit/dto/chat/ChatDto.java
@@ -32,6 +32,8 @@ public class ChatDto {
     private String opponent_nickname;
     private String opponent_image;
 
+    private Boolean opponentIsBlocked; // 쪽지를 보낸 유저가 차단된 유저인지 판단
+
     @Getter
     @NoArgsConstructor
     public static class ChatInfo {
@@ -52,7 +54,7 @@ public class ChatDto {
         }
     }
 
-    public ChatDto(ChatRoom chatRoom, Slice<ChatInfo> chatList) {
+    public ChatDto(ChatRoom chatRoom, Slice<ChatInfo> chatList, Boolean opponentIsBlocked) {
         Post getPost = chatRoom.getPost();
         if (getPost != null) {
             this.board_id = getPost.getBoard().getId();
@@ -79,11 +81,12 @@ public class ChatDto {
             this.opponent_id = chatRoom.getSender().getId();
             this.opponent_nickname = chatRoom.getSender().getNickName();
         }
-
+        this.opponentIsBlocked = opponentIsBlocked;
     }
 
     public void updateImage(String imageUrl) {
         this.opponent_image = imageUrl;
     }
+    public void updateIsBlocked(Boolean opponentIsBlocked) { this.opponentIsBlocked = opponentIsBlocked; }
 
 }

--- a/src/main/java/FIS/iLUVit/exception/BlockedErrorResult.java
+++ b/src/main/java/FIS/iLUVit/exception/BlockedErrorResult.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum BlockedErrorResult implements ErrorResult {
     ALREADY_BLOCKED_EXIST(HttpStatus.BAD_REQUEST, "이미 차단한 유저입니다."),
     IS_SAME_USER(HttpStatus.BAD_REQUEST, "자기 자신을 차단할 수는 없습니다."),
+    NOT_EXIST_BLOCKED(HttpStatus.NOT_FOUND, "존재하지 않는 차단관계입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/FIS/iLUVit/repository/ChatRepository.java
+++ b/src/main/java/FIS/iLUVit/repository/ChatRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 
@@ -20,8 +21,20 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
     @Query("select c from Chat c " +
             "join fetch c.chatRoom cr " +
             "where cr.id = :roomId " +
-            "and cr.receiver.id = :userId and cr.sender not in :blockedUsers " +
+            "and cr.receiver.id = :userId " +
             "order by c.createdDate desc ")
-    Slice<Chat> findByChatRoom(@Param("userId") Long userId, List<User> blockedUsers, @Param("roomId") Long roomId, Pageable pageable);
+    Slice<Chat> findByChatRoom(@Param("userId") Long userId,
+                               @Param("roomId") Long roomId,
+                               Pageable pageable);
 
+    @Query("select c from Chat c " +
+            "join fetch c.chatRoom cr " +
+            "where cr.id = :roomId " +
+            "and cr.receiver.id = :userId " +
+            "and c.createdDate <= :blockedDate " +
+            "order by c.createdDate desc ")
+    Slice<Chat> findByChatRoom(@Param("userId") Long userId,
+                               @Param("roomId") Long roomId,
+                               @Param("blockedDate") LocalDateTime blockedDate,
+                               Pageable pageable);
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #397 

## 📌 작업 내용
- 쪽지를 보낸 사람을 차단하면 차단 이후 받은 쪽지는 더 이상 보이지 않습니다

## 📚 기타
- contains는 equals()와 hasCode()를 이용하는데, 현재 오버라이드한 equals 로직이 제대로 동작하지 않아 contains 관련 로직 수행에 문제가 있었습니다. https://github.com/FISOLUTION/iluvit-backend/issues/400 이슈 발행하여 해당 문제 해결 먼저 한 뒤 테스트 해보니 잘 되는 것 확인하여 pr 날립니당!
