### PR TITLE
[FIX] 쿼리문 오류 해결

### DIFF
--- a/src/main/java/FIS/iLUVit/repository/BoardBookmarkRepository.java
+++ b/src/main/java/FIS/iLUVit/repository/BoardBookmarkRepository.java
@@ -33,7 +33,7 @@ public interface BoardBookmarkRepository extends JpaRepository<Bookmark, Long> {
     @Query("select p from Post p join fetch p.board b where p.id in " +
             "(select max(p.id) from Post p where p.board.id in " +
             "(select b.board.id from Bookmark b where b.user.id = :userId) " +
-            "group by p.board.id) and p.board.id = b.id and p.user.id not in :blockedUserIds ")
+            "group by p.board.id) and p.board.id = b.id and (:blockedUserIds is null or p.user.id not in :blockedUserIds) ")
     List<Post> findPostByBoard(@Param("userId") Long userId, @Param("blockedUserIds") List<Long> blockedUserIds);
 
     /*

--- a/src/main/java/FIS/iLUVit/repository/PostRepository.java
+++ b/src/main/java/FIS/iLUVit/repository/PostRepository.java
@@ -34,27 +34,17 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
      */
     @Query(value = "select * from " +
             "(select row_number() over (partition by p.board_id order by p.created_date desc) as ranks, " +
-            "p.* from post p where p.board_id in :boardIds and p.user_id not in :blockedUserIds) as ranking " +
+            "p.* from post p where p.board_id in :boardIds and (:blockedUserIds is null or p.user_id not in :blockedUserIds)) as ranking " +
             "where ranking.ranks <= 3 " +
             "order by board_id, created_date desc ",
             nativeQuery = true)
     List<Post> findTop3(@Param("boardIds") List<Long> boardIds, @Param("blockedUserIds") List<Long> blockedUserIds);
 
     /*
-        게시판 id 리스트 중 최근 3개의 게시글 리스트를 불러옵니다.
-     */
-    @Query(value = "select * from " +
-            "(select row_number() over (partition by p.board_id order by p.createddate desc) as ranks, " +
-            "p.* from post p where p.board_id in :boardIds) as ranking " +
-            "where ranking.ranks <= 3 order by board_id, createddate desc ",
-            nativeQuery = true)
-    List<Post> findTop3_H2(@Param("boardIds") List<Long> boardIds);
-
-    /*
         게시글 하트 개수가 가장 많은 3개의 게시글 리스트를 불러옵니다.
      */
     @Query("select p from Post p join p.board b " +
-            "where b.center is null and p.heartCnt >= :heartCnt and p.user.id not in :blockedUserIds " +
+            "where b.center is null and p.heartCnt >= :heartCnt and (:blockedUserIds is null or p.user.id not in :blockedUserIds) " +
             "order by p.postCreateDate desc ")
     List<Post> findTop3ByHeartCnt(@Param("heartCnt") int heartCnt, @Param("blockedUserIds") List<Long> blockedUserIds);
 
@@ -62,7 +52,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
         시설에 있는 게시글중 하트가 가장 많은 3개의 게시글 리스트를 불러옵니다.
      */
     @Query("select p from Post p join p.board b " +
-            "where b.center.id = :centerId and p.heartCnt >= :heartCnt and p.user.id not in :blockedUserIds " +
+            "where b.center.id = :centerId and p.heartCnt >= :heartCnt and (:blockedUserIds is null or p.user.id not in :blockedUserIds) " +
             "order by p.postCreateDate desc ")
     List<Post> findTop3ByHeartCntWithCenter(@Param("heartCnt") int heartCnt, @Param("centerId") Long centerId,
                                             @Param("blockedUserIds") List<Long> blockedUserIds);

--- a/src/main/java/FIS/iLUVit/service/PostService.java
+++ b/src/main/java/FIS/iLUVit/service/PostService.java
@@ -247,6 +247,7 @@ public class PostService {
 
         List<Bookmark> bookmarkList = boardBookmarkRepository.findBoardByUser(userId);
 
+
         getBoardPreviews(bookmarkList, boardPreviews, blockedUserIds);
 
         // HOT 게시판 정보 추가 ( 유저가 차단한 유저 리스트를 넘겨주어 해당 게시물은 조회되지 않게 한다)
@@ -310,6 +311,7 @@ public class PostService {
                 .collect(Collectors.toList());
 
         List<Post> top4 = postRepository.findTop3(boardIds,blockedUserIds);
+
         Map<Board, List<Post>> boardPostMap = top4.stream()
                 .collect(Collectors.groupingBy(post -> post.getBoard()));
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #392

## 📌 작업 내용
아래 두 api에서 blackUserIds가 빈배열 일 때  쿼리문 오류 해결
- /post/public-main (모두의 이야기 게시판 전체조회)
- /post/center-main?center_id=${id} (시설별 이야기 게시판 전체 조회)

## 📚 기타

