### PR TITLE
[FEAT] 익명인 경우도 writerId 보내주도록 수정

### DIFF
--- a/src/main/java/FIS/iLUVit/dto/comment/CommentResponse.java
+++ b/src/main/java/FIS/iLUVit/dto/comment/CommentResponse.java
@@ -33,6 +33,8 @@ public class CommentResponse {
         this.id = comment.getId();
         User writer = comment.getUser();
         if (writer != null) { // 삭제된 댓글은 wirter 가 null
+            this.writer_id = writer.getId();
+
             if (Objects.equals(writer.getId(), userId)) {
                 this.canDelete = true;
             } else {
@@ -45,10 +47,9 @@ public class CommentResponse {
                 } else {
                     this.nickname = "익명" + comment.getAnonymousOrder();
                 }
-                this.writer_id = writer.getId();
+
             } else {
                 this.profileImage = writer.getProfileImagePath();
-                this.writer_id = writer.getId();
                 this.nickname = writer.getNickName();
             }
         }

--- a/src/main/java/FIS/iLUVit/dto/comment/CommentResponse.java
+++ b/src/main/java/FIS/iLUVit/dto/comment/CommentResponse.java
@@ -32,7 +32,7 @@ public class CommentResponse {
     public CommentResponse(Comment comment, Long userId, List<CommentResponse> subComments, Boolean isBlocked) {
         this.id = comment.getId();
         User writer = comment.getUser();
-        if (writer != null) {
+        if (writer != null) { // 삭제된 댓글은 wirter 가 null
             if (Objects.equals(writer.getId(), userId)) {
                 this.canDelete = true;
             } else {
@@ -45,6 +45,7 @@ public class CommentResponse {
                 } else {
                     this.nickname = "익명" + comment.getAnonymousOrder();
                 }
+                this.writer_id = writer.getId();
             } else {
                 this.profileImage = writer.getProfileImagePath();
                 this.writer_id = writer.getId();
@@ -64,7 +65,9 @@ public class CommentResponse {
         this.id = comment.getId();
         User writer = comment.getUser();
         if (writer != null) {
-            if (Objects.equals(writer.getId(), userId)) {
+            this.writer_id = writer.getId();
+
+            if(Objects.equals(writer.getId(), userId)) {
                 this.canDelete = true;
             } else {
                 this.canDelete = false;
@@ -78,7 +81,6 @@ public class CommentResponse {
                 }
             } else {
                 this.profileImage = writer.getProfileImagePath();
-                this.writer_id = writer.getId();
                 this.nickname = writer.getNickName();
             }
         }

--- a/src/main/java/FIS/iLUVit/dto/post/PostResponse.java
+++ b/src/main/java/FIS/iLUVit/dto/post/PostResponse.java
@@ -48,6 +48,7 @@ public class PostResponse {
     public PostResponse(Post post, List<String> infoImages, String profileImage,Long userId, List<CommentResponse> commentResponses) {
         this.id = post.getId();
         if (post.getUser() != null) {
+            this.writer_id = post.getUser().getId();
             if (Objects.equals(post.getUser().getId(), userId)) {
                 this.canDelete = true;
             } else {
@@ -56,7 +57,6 @@ public class PostResponse {
             if (post.getAnonymous()) {
                 this.nickname = "익명";
             } else {
-                this.writer_id = post.getUser().getId();
                 this.nickname = post.getUser().getNickName();
             }
         }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #461 

## 📌 작업 내용
- 게시글 상세 조회 api에서 익명인 경우도 post 와 comment의 writerId를 보내주도록 수정한다

## 📚 기타

