### PR TITLE
[FEAT] 로그인 예외처리 로직 추가

### DIFF
--- a/src/main/java/FIS/iLUVit/exception/UserErrorResult.java
+++ b/src/main/java/FIS/iLUVit/exception/UserErrorResult.java
@@ -18,7 +18,8 @@ public enum UserErrorResult implements ErrorResult {
     ALREADY_NICKNAME_EXIST(HttpStatus.BAD_REQUEST, "이미 존재 하는 닉네임입니다."),
     USER_IS_BLACK(HttpStatus.EXPECTATION_FAILED, "차단된 유저입니다."),
     USER_IS_WITHDRAWN(HttpStatus.PRECONDITION_FAILED, "탈퇴 후 15일이 지나지 않은 유저입니다."),
-    USER_IS_BLACK_OR_WITHDRAWN(HttpStatus.EXPECTATION_FAILED, "차단 됐거나 탈퇴 후 15일이 지나지 않은 유저입니다.")
+    USER_IS_BLACK_OR_WITHDRAWN(HttpStatus.EXPECTATION_FAILED, "차단 됐거나 탈퇴 후 15일이 지나지 않은 유저입니다."),
+    BAD_LOGIN_OR_PASSWORD(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 잘못되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/FIS/iLUVit/exception/UserErrorResult.java
+++ b/src/main/java/FIS/iLUVit/exception/UserErrorResult.java
@@ -19,7 +19,7 @@ public enum UserErrorResult implements ErrorResult {
     USER_IS_BLACK(HttpStatus.EXPECTATION_FAILED, "차단된 유저입니다."),
     USER_IS_WITHDRAWN(HttpStatus.PRECONDITION_FAILED, "탈퇴 후 15일이 지나지 않은 유저입니다."),
     USER_IS_BLACK_OR_WITHDRAWN(HttpStatus.EXPECTATION_FAILED, "차단 됐거나 탈퇴 후 15일이 지나지 않은 유저입니다."),
-    BAD_LOGIN_OR_PASSWORD(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 잘못되었습니다."),
+    BAD_LOGIN_OR_PASSWORD(HttpStatus.UNAUTHORIZED, "아이디 혹은 비밀번호가 잘못되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/FIS/iLUVit/repository/UserRepository.java
+++ b/src/main/java/FIS/iLUVit/repository/UserRepository.java
@@ -87,4 +87,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
         전화번호와 사용자 id로 User를 받아옵니다.
      */
     Optional<User> findByIdAndPhoneNumber(Long id, String phoneNumber);
+
+    /**
+     * 로그인 아이디와 비밀번호로 유저를 조회합니다
+     */
+    Optional<User> findByLoginIdAndPassword(String loginId, String password);
 }

--- a/src/main/java/FIS/iLUVit/service/UserService.java
+++ b/src/main/java/FIS/iLUVit/service/UserService.java
@@ -110,11 +110,18 @@ public class UserService {
      *   작성내용: login service layer로 옮김
      */
     public LoginResponse login(LoginRequest request) {
+        String loginId = request.getLoginId();
+        String password = request.getPassword();
+
         // 영구정지, 일주일간 이용제한인 유저인지 검증
-        blackUserRepository.findRestrictedByLoginId(request.getLoginId())
+        blackUserRepository.findRestrictedByLoginId(loginId)
                 .ifPresent(blackUser -> {
                     throw new UserException(UserErrorResult.USER_IS_BLACK_OR_WITHDRAWN);
                 });
+
+        // 로그인 아이디, 비밀번호 검증 에러 처리
+        userRepository.findByLoginIdAndPassword(loginId, password)
+                .orElseThrow(()-> new UserException(UserErrorResult.BAD_LOGIN_OR_PASSWORD));
 
         // authenticationManager 이용한 아이디 및 비밀번호 확인
         Authentication authentication = authenticationManager.authenticate(


### PR DESCRIPTION
## 🌱 관련 이슈
- close #480

## 📌 작업 내용
-  로그인 시 아이디 또는 비밀번호가 틀리면 '아이디 또는 비밀번호가 잘못되었습니다.' 라는 오류 메시지가 가도록 한다

## 📚 기타

