### PR TITLE
[FIX] 주소 관련 에러 처리 수정

### DIFF
--- a/src/main/java/FIS/iLUVit/dto/parent/ParentDetailRequest.java
+++ b/src/main/java/FIS/iLUVit/dto/parent/ParentDetailRequest.java
@@ -23,7 +23,7 @@ public class ParentDetailRequest {
     private String phoneNum;
     @NotEmpty(message = "입력하지 않은 목록이 있습니다.")
     private String address;
-    @NotEmpty(message = "입력하지 않은 목록이 있습니다.")
+    @NotNull
     private String detailAddress;
     @NotEmpty(message = "입력하지 않은 목록이 있습니다.")
     private String emailAddress;

--- a/src/main/java/FIS/iLUVit/dto/parent/SignupParentRequest.java
+++ b/src/main/java/FIS/iLUVit/dto/parent/SignupParentRequest.java
@@ -32,7 +32,7 @@ public class SignupParentRequest {
     private String emailAddress;
     @NotNull(message = "입력하지 않은 목록이 있습니다.")
     private String address;
-    @NotNull(message = "입력하지 않은 목록이 있습니다.")
+    @NotNull
     private String detailAddress;
     private Theme theme;
     @NotNull(message = "입력하지 않은 목록이 있습니다.")

--- a/src/main/java/FIS/iLUVit/dto/teacher/SignupTeacherRequest.java
+++ b/src/main/java/FIS/iLUVit/dto/teacher/SignupTeacherRequest.java
@@ -31,7 +31,7 @@ public class SignupTeacherRequest {
     private String emailAddress;
     @NotNull(message = "입력하지 않은 목록이 있습니다.")
     private String address;
-    @NotNull(message = "입력하지 않은 목록이 있습니다.")
+    @NotNull
     private String detailAddress;
     private Long centerId;
 

--- a/src/main/java/FIS/iLUVit/dto/teacher/TeacherDetailRequest.java
+++ b/src/main/java/FIS/iLUVit/dto/teacher/TeacherDetailRequest.java
@@ -25,7 +25,7 @@ public class TeacherDetailRequest {
     private String emailAddress;
     @NotEmpty(message = "입력되지 않은 목록이 있습니다.")
     private String address;
-    @NotEmpty(message = "입력되지 않은 목록이 있습니다.")
+    @NotNull
     private String detailAddress;
     private MultipartFile profileImg;
 }

--- a/src/main/java/FIS/iLUVit/exception/CenterErrorResult.java
+++ b/src/main/java/FIS/iLUVit/exception/CenterErrorResult.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CenterErrorResult implements ErrorResult {
     CENTER_NOT_EXIST(HttpStatus.I_AM_A_TEAPOT, "해당 아이디를 가진 센터가 존재하지 않습니다."),
-    CENTER_WRONG_ADDRESS(HttpStatus.BAD_REQUEST, "잘못된 시설 주소입니다"),
     CENTER_ADDRESS_CONVERT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류 입니다"),
     AUTHENTICATION_FAILED(HttpStatus.FORBIDDEN, "권한이 없습니다.");
 

--- a/src/main/java/FIS/iLUVit/exception/UserErrorResult.java
+++ b/src/main/java/FIS/iLUVit/exception/UserErrorResult.java
@@ -18,7 +18,8 @@ public enum UserErrorResult implements ErrorResult {
     ALREADY_NICKNAME_EXIST(HttpStatus.BAD_REQUEST, "이미 존재 하는 닉네임입니다."),
     USER_IS_BLACK(HttpStatus.EXPECTATION_FAILED, "차단된 유저입니다."),
     USER_IS_WITHDRAWN(HttpStatus.PRECONDITION_FAILED, "탈퇴 후 15일이 지나지 않은 유저입니다."),
-    USER_IS_BLACK_OR_WITHDRAWN(HttpStatus.EXPECTATION_FAILED, "차단 됐거나 탈퇴 후 15일이 지나지 않은 유저입니다.")
+    USER_IS_BLACK_OR_WITHDRAWN(HttpStatus.EXPECTATION_FAILED, "차단 됐거나 탈퇴 후 15일이 지나지 않은 유저입니다."),
+    WRONG_ADDRESS(HttpStatus.BAD_REQUEST, "잘못된 주소입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/FIS/iLUVit/service/MapService.java
+++ b/src/main/java/FIS/iLUVit/service/MapService.java
@@ -2,6 +2,8 @@ package FIS.iLUVit.service;
 
 import FIS.iLUVit.exception.CenterErrorResult;
 import FIS.iLUVit.exception.CenterException;
+import FIS.iLUVit.exception.UserErrorResult;
+import FIS.iLUVit.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -47,7 +49,7 @@ public class MapService {
                     Double.parseDouble(addressResponse.get("y").toString())
             );
         } catch (Exception ex){
-            throw new CenterException(CenterErrorResult.CENTER_WRONG_ADDRESS);
+            throw new UserException(UserErrorResult.WRONG_ADDRESS);
         }
     }
 
@@ -73,7 +75,7 @@ public class MapService {
             // x 가 longitude y가 latitude
             return Pair.of(sido, sigungu);
         } catch (Exception ex){
-            throw new CenterException(CenterErrorResult.CENTER_WRONG_ADDRESS);
+            throw new UserException(UserErrorResult.WRONG_ADDRESS);
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #447 

## 📌 작업 내용
- 교사 회원가입, 교사 정보 수정, 학부모 회원가입, 학부모 정보 수정에서 요청객체 내 주소를 받을 때 주소 ( `address` )는 @NotNull이 맞지만, 상세주소 ( `detailAddress` )는 없을 수도 있으므로 @NotNull 어노테이션의 message condition을 제거해주었습니다. 
- 상세주소를 저장하거나 업데이트하는 request dto 내 detailAddress 에 @NotEmpty가 붙어있는 것을 @NotNull로 변경하고 message를 제거해주었습니다.
- naver OpenAPI 사용하여 주소 String으로 위경도 반환하는 메서드 ( `convertAddressToLocation` )와 시도시군구 반환하는 메서드 ( `getSidoSigunguByLocation` ) 의 에러처리로 잘못된 메세지를 반환하고 있습니다. 시설 주소가 아닌데 CenterException으로 `잘못된 시설 주소입니다.` 라는 에러 메세지를 반환중이므로 UserException으로 처리하고 `잘못된 주소입니다.` 라고 반환하도록 에러처리를 변경하였습니다.

## 📚 기타
- 클라이언트에서 검증된 값을 이중으로 서버단에서 검증해주어야하는 것은 맞지만 현재 서버단의 유효성 검증이 1차 검증인 경우가 있습니다. 클라이언트와 상의하여 클라단에서 어떤 값을 검증하는지 파악하고 클라단에서 1차 검증이 이루어지도록 해야할 것 같습니다.
